### PR TITLE
add git pre-commit syntax and psr2 check

### DIFF
--- a/scripts/pre-commit.php
+++ b/scripts/pre-commit.php
@@ -1,0 +1,40 @@
+#!/usr/bin/php
+<?php
+/**
+ * .git/hooks/pre-commit
+ *
+ * This pre-commit hooks will check for PHP error (lint), and make sure the code
+ * is PSR compliant.
+ *
+ * Dependecy: PHP-CS-Fixer (https://github.com/fabpot/PHP-CS-Fixer)
+ *
+ * @author  Mardix  http://github.com/mardix
+ * @since   Sept 4 2012
+ *
+ */
+
+
+// collect all files which have been added, copied or modified
+exec('git diff --cached --name-status --diff-filter=ACM', $output);
+
+foreach ($output as $file) {
+    $fileName = trim(substr($file, 1));
+    if (pathinfo($fileName, PATHINFO_EXTENSION) == "php") {
+
+        // Check for lint errors
+        $lint_output = array();
+        exec("php -l " . escapeshellarg($fileName), $lint_output, $return);
+
+        if ($return === 0) {
+            /**
+             * PHP-CS-Fixer && add it back
+             */
+            exec("vendor/bin/php-cs-fixer fix {$fileName} --level=psr2; git add {$fileName}");
+        } else {
+            echo implode("\n", $lint_output), "\n";
+            exit(1);
+        }
+    }
+}
+
+exit(0);

--- a/setup_dev_box.sh
+++ b/setup_dev_box.sh
@@ -9,3 +9,7 @@ source ~/.bash_profile
 homestead init
 cp Homestead.yaml ~/.homestead/
 homestead up
+
+# setup a git hook to check your commits before you push them
+cp scripts/pre-commit.php .git/hooks/pre-commit
+


### PR DESCRIPTION
git hooks must be installed in each checkout, so added a copy command to dev setup script.

To get this in an existing checkout, after it lands just run:

cp scripts/pre-commit.php .git/hooks/pre-commit
