### PR TITLE
[Fixes #97465826] - run jshint and jscs on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "gulp-autoprefixer": "~2.3.1",
     "gulp-angular-templatecache": "~1.5.0",
     "del": "~1.1.1",
+    "jscs": "~1.13.1",
+    "jshint": "~2.8.0",
     "lodash": "~3.2.0",
     "gulp-csso": "~1.0.0",
     "gulp-filter": "~2.0.2",

--- a/scripts/pre-commit.php
+++ b/scripts/pre-commit.php
@@ -24,6 +24,11 @@ foreach ($output as $fileName) {
         if (runCheck("vendor/bin/php-cs-fixer fix $fileName --level=psr2 --fixers=-psr0")) {
             exec("git add $fileName");
         }
+    } elseif ($ext === 'js') {
+        runCheck("./node_modules/.bin/jshint {$fileName}");
+        if (runCheck("./node_modules/.bin/jscs -x {$fileName}")) {
+            exec("git add $fileName");
+        }
     }
 }
 


### PR DESCRIPTION
Check all js files with jshint and jscs on every commit, and fix when possible just as we do with php commits.
