### PR TITLE
make unit tests (eventually) run in-memory sqlite db

### DIFF
--- a/database/migrations/2015_06_22_214714_add_drug_label.php
+++ b/database/migrations/2015_06_22_214714_add_drug_label.php
@@ -13,7 +13,7 @@ class AddDrugLabel extends Migration
     public function up()
     {
         Schema::table('drugs', function (Blueprint $table) {
-            $table->string('label');
+            $table->string('label')->default('');
             $table->string('description')->nullable();
         });
     }

--- a/database/migrations/2015_06_24_024822_add-drug-fields.php
+++ b/database/migrations/2015_06_24_024822_add-drug-fields.php
@@ -13,9 +13,9 @@ class AddDrugFields extends Migration
     public function up()
     {
         Schema::table('drugs', function (Blueprint $table) {
-            $table->integer('rxcui');
+            $table->integer('rxcui')->default(0);
             $table->text('generic')->nullable();
-            $table->json('drug_forms');
+            $table->json('drug_forms')->default('');
         });
     }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,9 +21,8 @@
     </filter>
     <php>
         <env name="APP_ENV" value="testing"/>
-        <env name="DB_DATABASE" value="homestead"/>
-        <env name="DB_USERNAME" value="homestead"/>
-        <env name="DB_PASSWORD" value="secret"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,6 +9,11 @@ class TestCase extends Laravel\Lumen\Testing\TestCase
      */
     public function createApplication()
     {
-        return require __DIR__.'/../bootstrap/app.php';
+        return require __DIR__ . '/../bootstrap/app.php';
+    }
+
+    public function setupDatabase()
+    {
+        \Illuminate\Support\Facades\Artisan::call('migrate');
     }
 }


### PR DESCRIPTION
This does not really start using sqlite yet, but it sets up phpunit config and provides an initial helper method. I ended up not needing it for controllers, but it will be needed for integration tests.

The real reason for a pull request was to review migration changes. Should be OK, but just making sure.
