### PR TITLE
let JWT tell us if the token expired, and add tests

### DIFF
--- a/app/Http/Middleware/AuthMiddleware.php
+++ b/app/Http/Middleware/AuthMiddleware.php
@@ -38,13 +38,13 @@ class AuthMiddleware
         if ($request->header('Authorization')) {
             $token = explode(' ', $request->header('Authorization'))[1];
             try {
-                $payload = (array) JWT::decode($token, env('APP_KEY'), array('HS256'));
-                if ($payload['exp'] < time()) {
-                    return response()->json(['message' => 'Token has expired']);
-                }
-                $request['user'] = $payload;
+                $request['user'] = (array) JWT::decode($token, env('APP_KEY'), array('HS256'));
             } catch (\Exception $e) {
-                return response()->json(['message' => 'Token could not be decoded']);
+                $message = 'Token could not be decoded';
+                if ($e->getMessage() === 'Expired token') {
+                    $message = 'Token has expired';
+                }
+                return response()->json(['message' => $message]);
             }
             return $next($request);
         } else {

--- a/tests/Http/Middleware/AuthMiddlewareTest.php
+++ b/tests/Http/Middleware/AuthMiddlewareTest.php
@@ -44,4 +44,39 @@ class AuthMiddlewareTest extends TestCase
 
         $this->assertContains('Token could not be decoded', $response->getContent());
     }
+
+    public function testHandleWithToken()
+    {
+        $payload = [
+            'sub' => 'foo',
+            'iat' => time() - 1,
+            'exp' => time() + 10
+        ];
+
+        $token = JWT::encode($payload, env('APP_KEY'));
+        $this->request->shouldReceive('header')->twice()->with('Authorization')->andReturn('foo ' . $token);
+        $this->request->shouldReceive('offsetSet')->once();
+        $this->request->shouldReceive('getResponse')->once();
+
+        $response = $this->middle->handle($this->request, function ($request) {
+            $request->getResponse();
+        });
+        $this->assertNull($response);
+    }
+
+    public function testExpiredToken()
+    {
+        $payload = [
+            'sub' => 'foo',
+            'iat' => time() -10,
+            'exp' => time() -1
+        ];
+
+        $token = JWT::encode($payload, env('APP_KEY'));
+        $this->request->shouldReceive('header')->twice()->with('Authorization')->andReturn('foo ' . $token);
+
+        $response = $this->middle->handle($this->request, function () {});
+
+        $this->assertContains('Token has expired', $response->getContent());
+    }
 }


### PR DESCRIPTION
JWT will never return an array if the token expired, no need to check that ourselves, but we do want to show a different message in that case (if there is any other problem with the token, we do not say what it is for security reasons)
