### PR TITLE
[Fixes #98293962] add html/body tags to improve email rendering

### DIFF
--- a/resources/views/emails/forgot-password.php
+++ b/resources/views/emails/forgot-password.php
@@ -1,6 +1,14 @@
-<link href='//fonts.googleapis.com/css?family=Lato' rel='stylesheet' type='text/css'>
-
-<table style="background-color:#f2f2f2" border="0" cellspacing="0" cellpadding="0" width="100%" bgcolor="#f2f2f2">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <title>Password reset</title>
+        <link href='https://fonts.googleapis.com/css?family=Lato' rel='stylesheet' type='text/css'>
+    </head>
+    <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
+    <table style="background-color:#f2f2f2" border="0" cellspacing="0" cellpadding="0" width="100%" bgcolor="#f2f2f2">
     <tbody>
     <tr>
         <td style="background-color:#f2f2f2" align="center" bgcolor="#f2f2f2">
@@ -77,8 +85,10 @@
         </td>
     </tr>
     </tbody>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
+    </table>
+    </td>
+    </tr>
+    </tbody>
+    </table>
+    </body>
+</html>


### PR DESCRIPTION
Now you can actually see the message in iOS

See https://github.com/mailchimp/Email-Blueprints if we need to make the template more responsive etc.
